### PR TITLE
Bump Golang ecosystem to 1.27 version; small refactoring

### DIFF
--- a/.github/workflows/tpl_validate_golang.yml
+++ b/.github/workflows/tpl_validate_golang.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GOLANGCI_LINT_VERSION: v2.12.2
+      GOLANGCI_LINT_VERSION: v2.13.0
 
     steps:
       - name: 'Checkout code'

--- a/.github/workflows/tpl_validate_golang.yml
+++ b/.github/workflows/tpl_validate_golang.yml
@@ -20,6 +20,22 @@ jobs:
         with:
           go-version-file: cmd/token-injector/go.mod
 
+      - name: 'Test token-injector'
+        working-directory: cmd/token-injector
+        run: go test -timeout 15s ./...
+
+      - name: 'Test token-injector-webhook'
+        working-directory: cmd/token-injector-webhook
+        run: go test -timeout 15s ./...
+
+      - name: 'Build token-injector'
+        working-directory: cmd/token-injector
+        run: go build -o /dev/null .
+
+      - name: 'Build token-injector-webhook'
+        working-directory: cmd/token-injector-webhook
+        run: go build -o /dev/null .
+
       - name: 'Detect token-injector changes'
         uses: dorny/paths-filter@v4
         id: changes-token-injector

--- a/cmd/token-injector-webhook/Dockerfile
+++ b/cmd/token-injector-webhook/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.27-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v2.12.2-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v2.13.0-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----

--- a/cmd/token-injector-webhook/Dockerfile
+++ b/cmd/token-injector-webhook/Dockerfile
@@ -3,11 +3,11 @@
 #
 # ----- Go Builder Image ------
 #
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v2.9-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v2.12.2-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----

--- a/cmd/token-injector-webhook/go.mod
+++ b/cmd/token-injector-webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/ealebed/token-injector/token-injector-webhook
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/cmd/token-injector-webhook/main.go
+++ b/cmd/token-injector-webhook/main.go
@@ -3,12 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -75,18 +74,14 @@ var logger *log.Logger
 
 // randomString generates a random string of lowercase a-z characters with the specified length (l).
 // If testMode is enabled, it returns a string of repeated '0' characters of the specified length.
-// Otherwise, it creates a new random generator seeded with the current time (in nanoseconds)
-// to ensure different outputs each time it's called. The function then fills a byte slice with
-// random letters from 'a' to 'z' and converts it to a string before returning.
 func randomString(l int) string {
 	if testMode {
 		return strings.Repeat("0", l)
 	}
-	r := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404
-	bytes := make([]byte, l)
 	const letters = "abcdefghijklmnopqrstuvwxyz"
+	bytes := make([]byte, l)
 	for i := range bytes {
-		bytes[i] = letters[r.Intn(len(letters))]
+		bytes[i] = letters[rand.IntN(len(letters))] // #nosec G404 -- session name suffix, not a security token
 	}
 
 	return string(bytes)

--- a/cmd/token-injector/Dockerfile
+++ b/cmd/token-injector/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.27-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v2.12.2-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v2.13.0-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----

--- a/cmd/token-injector/Dockerfile
+++ b/cmd/token-injector/Dockerfile
@@ -3,11 +3,11 @@
 #
 # ----- Go Builder Image ------
 #
-FROM golang:1.26-alpine AS builder
+FROM golang:1.27-alpine AS builder
 
 # curl git bash
 RUN apk add --no-cache curl git bash make
-COPY --from=golangci/golangci-lint:v2.9-alpine /usr/bin/golangci-lint /usr/bin
+COPY --from=golangci/golangci-lint:v2.12.2-alpine /usr/bin/golangci-lint /usr/bin
 
 #
 # ----- Build and Test Image -----

--- a/cmd/token-injector/go.mod
+++ b/cmd/token-injector/go.mod
@@ -1,6 +1,6 @@
 module github.com/ealebed/token-injector/token-injector
 
-go 1.26.0
+go 1.27.0
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/cmd/token-injector/internal/gcp/sainfo.go
+++ b/cmd/token-injector/internal/gcp/sainfo.go
@@ -20,10 +20,10 @@ import (
 // observed to timeout often on GKE when using Workload Identities.
 var metadataClient = metadata.NewClient(&http.Client{
 	Transport: &http.Transport{
-		Dial: (&net.Dialer{
+		DialContext: (&net.Dialer{
 			Timeout:   10 * time.Second,
 			KeepAlive: 30 * time.Second,
-		}).Dial,
+		}).DialContext,
 		ResponseHeaderTimeout: 15 * time.Second, // default is 2
 	},
 })

--- a/cmd/token-injector/internal/gcp/token.go
+++ b/cmd/token-injector/internal/gcp/token.go
@@ -78,32 +78,20 @@ func (IDToken) GetDuration(jwtToken string) (time.Duration, error) {
 }
 
 func (IDToken) WriteToFile(token, fileName string) error {
-	// this is a slice of io.Writers we will write the file to
-	var writers []io.Writer
-
-	// if no file provided
-	if fileName == "" {
-		writers = append(writers, os.Stdout)
-	}
-
-	// if DestFile was provided, lets try to create it and add to the writers
+	dest := io.Writer(os.Stdout)
 	if fileName != "" {
 		file, err := os.Create(fileName) //nolint:gosec // G304: fileName is controlled by user input
 		if err != nil {
 			return fmt.Errorf("failed to create token file: %s; error: %s", fileName, err.Error())
 		}
-		writers = append(writers, file)
 		defer func() {
 			if closeErr := file.Close(); closeErr != nil {
 				// Log error but don't fail if file was already written
 				log.Printf("failed to close file: %s", closeErr)
 			}
 		}()
+		dest = file
 	}
-	// MultiWriter(io.Writer...) returns a single writer which multiplexes its
-	// writes across all of the writers we pass in.
-	dest := io.MultiWriter(writers...)
-	// write to dest the same way as before, copying from the Body
 	if _, err := io.WriteString(dest, token); err != nil {
 		return fmt.Errorf("failed to write token: %s", err.Error())
 	}


### PR DESCRIPTION
### Code simplifications
- `randomString` — switched to `math/rand/v2` (auto-seeded, no manual `rand.NewSource`)
- `sainfo.go` — replaced deprecated `Transport.Dial` with `DialContext`
- `token.go` `WriteToFile` — removed unnecessary `MultiWriter` slice; direct s`tdout/file` write